### PR TITLE
Minor bugfixes / [feature] cmake uninstall target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -228,3 +228,11 @@ Run these commands to build this software and install it:
 You should now be able to run the command-line utility by running `pavr2cmd` in
 your shell, and you should be able to start the graphical configuration utility
 by running `pavr2gui`.
+
+
+## Uninstalling
+
+In order to uninstall this library, open a terminal and navigate to the build folder
+within this source code project using `cd` and enter the following command:
+
+    sudo make uninstall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,3 +110,20 @@ add_subdirectory (cli)
 if (ENABLE_GUI)
   add_subdirectory (gui)
 endif ()
+
+
+###
+# Uninstall target
+###
+
+if (NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+        )
+    add_custom_target(
+        uninstall COMMAND ${CMAKE_COMMAND}
+        -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake
+        )
+endif ()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if (NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif ()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach (file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if (IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program("@CMAKE_COMMAND@"
+            ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+        if (NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif ()
+    else (IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif ()
+endforeach ()

--- a/lib/programmer.cpp
+++ b/lib/programmer.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <thread>
 #include <chrono>
+#include <stdexcept>
 
 #include <programmer.h>
 #include <pavrpgm_config.h>
@@ -318,7 +319,7 @@ static uint8_t bcdToDecimal(uint8_t bcd)
 
 std::string ProgrammerInstance::getFirmwareVersionString() const
 {
-    char buffer[6];
+    char buffer[8];
     snprintf(buffer, sizeof(buffer), "%d.%02d",
         getFirmwareVersionMajor(), getFirmwareVersionMinor());
     return std::string(buffer);


### PR DESCRIPTION
Fixes the following compilation errors & warnings:

- `error: ‘runtime_error’ is not a member of ‘std’`
- `warning: ‘%02d’ directive output may be truncated writing between 2 and 3 bytes into a region of size between 2 and 4 [-Wformat-truncation=]

Adds an uninstall target for cmake / make.