### PR TITLE
Fixed compiler warning for Qt > v5.15

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,11 +1,11 @@
-#include <QApplication>
+#include <QGuiApplication>
 #include "main_model.h"
 #include "main_controller.h"
 #include "main_view.h"
 
 int main(int argc, char ** argv)
 {
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     MainModel model;
     MainController controller;
     MainView view;

--- a/gui/qt/main_window.cpp
+++ b/gui/qt/main_window.cpp
@@ -7,7 +7,6 @@
 #include "pavrpgm_config.h"
 #include "pavr2_protocol.h"
 
-#include <QApplication>
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QComboBox>
@@ -15,6 +14,7 @@
 #include <QDesktopWidget>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QGuiApplication>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMainWindow>
@@ -22,6 +22,7 @@
 #include <QMessageBox>
 #include <QProcessEnvironment>
 #include <QPushButton>
+#include <QScreen>
 #include <QSpinBox>
 #include <QStatusBar>
 #include <QTimer>
@@ -411,7 +412,7 @@ void MainWindow::centerAtStartupIfNeeded()
         Qt::LeftToRight,
         Qt::AlignCenter,
         size(),
-        qApp->desktop()->availableGeometry()
+        qApp->primaryScreen()->availableGeometry()
         )
       );
   }

--- a/gui/qt/main_window.cpp
+++ b/gui/qt/main_window.cpp
@@ -639,7 +639,7 @@ static void setupReadOnlyTextField(QGridLayout * layout, int row,
     newLabel->setBuddy(newValue);
 
     layout->addWidget(newLabel, row, 0, FIELD_LABEL_ALIGNMENT);
-    layout->addWidget(newValue, row, 1, 0);
+    layout->addWidget(newValue, row, 1, {});
 
     if (label) { *label = newLabel; }
     if (value) { *value = newValue; }
@@ -683,11 +683,11 @@ void MainWindow::setupWindow()
     QGridLayout * layout = centralWidgetLayout = new QGridLayout();
 
     int row = 0;
-    layout->addWidget(setupDeviceInfoBox(), row++, 0, 0);
-    layout->addWidget(setupProgrammingResultsBox(), row++, 0, 0);
-    layout->addWidget(setupCurrentStatusBox(), row++, 0, 0);
-    layout->addWidget(setupSettingsWidget(), 0, 1, row, 1, 0);
-    layout->addWidget(setupFooter(), row++, 0, 1, 2, 0);
+    layout->addWidget(setupDeviceInfoBox(), row++, {}, {});
+    layout->addWidget(setupProgrammingResultsBox(), row++, {}, {});
+    layout->addWidget(setupCurrentStatusBox(), row++, {}, {});
+    layout->addWidget(setupSettingsWidget(), {}, 1, row, 1, {});
+    layout->addWidget(setupFooter(), row++, {}, 1, 2, {});
 
     layout->setRowStretch(row, 1);
     centralWidget->setLayout(layout);
@@ -847,7 +847,7 @@ QWidget * MainWindow::setupProgrammingResultsBox()
         programmingErrorValue->sizeHint().height() * lineCount);
     programmingErrorValue->setAlignment(Qt::AlignTop);
     programmingErrorValue->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    layout->addWidget(programmingErrorValue, row++, 0, 1, 2, 0);
+    layout->addWidget(programmingErrorValue, row++, {}, 1, 2, {});
 
     layout->setRowStretch(row, 1);
     programmingResultsBox->setLayout(layout);
@@ -897,7 +897,7 @@ QWidget * MainWindow::setupSettingsWidget()
     layout->setContentsMargins(0, 0, 0, 0);
 
     int row = 0;
-    layout->addWidget(setupSettingsBox(), row++, 0, 0);
+    layout->addWidget(setupSettingsBox(), row++, {}, {});
 
     settingsWidget->setLayout(layout);
     return settingsWidget;


### PR DESCRIPTION
Fix for Qt5 deprecations:

1) Obsolete Member QApplication::desktop() results in the following compiler warning [-Wdeprecated-declarations]
'const QRect QDesktopWidget::availableGeometry(int) const' is deprecated.

2) ‘constexpr QFlags::QFlags(Zero) [with Enum = Qt::AlignmentFlag;
Zero = int QFlagsQt::AlignmentFlag::Private::*]’ is deprecated:
Use default constructor instead [-Wdeprecated-declarations].

This PR [Closes #3] [Closes #6].

